### PR TITLE
NC-1675 Ensure that default logging is appropriate

### DIFF
--- a/pantheon/src/main/resources/log4j2.xml
+++ b/pantheon/src/main/resources/log4j2.xml
@@ -6,11 +6,12 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />    </Console>
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg %throwable{short.message}%n"/>
+    </Console>
   </Appenders>
   <Loggers>
     <Root level="${sys:root.log.level}">
-      <AppenderRef ref="Console" />
+      <AppenderRef ref="Console"/>
     </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
Do not log stack traces by default.

## PR description

When an exception is logged all the java stack trace shows up in the default log configuration.  This looks like noise and should be removed unless desired.
